### PR TITLE
[MET-1274] add ts_json column for full text search in tx_metadata

### DIFF
--- a/src/main/resources/db/migration/V1_3_5__add_ts_json_column_support_for_full_text_search.sql
+++ b/src/main/resources/db/migration/V1_3_5__add_ts_json_column_support_for_full_text_search.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tx_metadata ADD COLUMN ts_json tsvector
+GENERATED ALWAYS AS (to_tsvector('simple', tx_metadata."json")) STORED;
+
+CREATE INDEX IF NOT EXISTS tx_metadata_ts_json_idx ON tx_metadata USING GIN (ts_json);


### PR DESCRIPTION
## Subject

- MET-1274 add ts_json column for full-text search in tx_metadata

## Changes Description
- [feat: add ts_json column for full text search in tx_metadata](https://github.com/cardano-foundation/cf-ledger-consumer-schedules/pull/107/commits/d00571d28ef9880ba2bcc233cad3a5dc3036a66d)

## Referenced Ticket

- https://cardanofoundation.atlassian.net/browse/MET-1274

## Note:
- I use feature full-text search of postgres to search policyId and assetName in "json" field of tx_metada. So this migration will add a new column support for that and take about 2 hours in mainnet.  